### PR TITLE
Fix #1404 Configure exponential backoff or randomized if base configu…

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/configuration/CommonRetryConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/configuration/CommonRetryConfigurationProperties.java
@@ -197,18 +197,16 @@ public class CommonRetryConfigurationProperties extends CommonProperties {
         if (maxWaitDuration != null &&
             randomizedWaitFactor != null &&
             backoffMultiplier != null) {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialRandomBackoff(waitDuration, backoffMultiplier, randomizedWaitFactor, maxWaitDuration));
+            withIntervalBiFunction(builder,
+                    IntervalFunction.ofExponentialRandomBackoff(waitDuration, backoffMultiplier, randomizedWaitFactor, maxWaitDuration));
         } else if (randomizedWaitFactor != null &&
             backoffMultiplier != null) {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialRandomBackoff(waitDuration, backoffMultiplier, randomizedWaitFactor));
+            withIntervalBiFunction(builder,
+                    IntervalFunction.ofExponentialRandomBackoff(waitDuration, backoffMultiplier, randomizedWaitFactor));
         } else if (backoffMultiplier != null) {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialRandomBackoff(waitDuration, backoffMultiplier));
+            withIntervalBiFunction(builder, IntervalFunction.ofExponentialRandomBackoff(waitDuration, backoffMultiplier));
         } else {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialRandomBackoff(waitDuration));
+            withIntervalBiFunction(builder, IntervalFunction.ofExponentialRandomBackoff(waitDuration));
         }
     }
 
@@ -218,14 +216,11 @@ public class CommonRetryConfigurationProperties extends CommonProperties {
         Duration maxWaitDuration = properties.getExponentialMaxWaitDuration();
         if (maxWaitDuration != null &&
             backoffMultiplier != null) {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialBackoff(waitDuration, backoffMultiplier, maxWaitDuration));
+            withIntervalBiFunction(builder, IntervalFunction.ofExponentialBackoff(waitDuration, backoffMultiplier, maxWaitDuration));
         } else if (backoffMultiplier != null) {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialBackoff(waitDuration, backoffMultiplier));
+            withIntervalBiFunction(builder, IntervalFunction.ofExponentialBackoff(waitDuration, backoffMultiplier));
         } else {
-            builder.intervalFunction(
-                IntervalFunction.ofExponentialBackoff(waitDuration));
+            withIntervalBiFunction(builder, IntervalFunction.ofExponentialBackoff(waitDuration));
         }
     }
 
@@ -233,12 +228,14 @@ public class CommonRetryConfigurationProperties extends CommonProperties {
         Duration waitDuration = properties.getWaitDuration();
         Double randomizedWaitFactor = properties.getRandomizedWaitFactor();
         if (randomizedWaitFactor != null) {
-            builder.intervalFunction(
-                IntervalFunction.ofRandomized(waitDuration, randomizedWaitFactor));
+            withIntervalBiFunction(builder, IntervalFunction.ofRandomized(waitDuration, randomizedWaitFactor));
         } else {
-            builder.intervalFunction(
-                IntervalFunction.ofRandomized(waitDuration));
+            withIntervalBiFunction(builder, IntervalFunction.ofRandomized(waitDuration));
         }
+    }
+
+    private void withIntervalBiFunction(RetryConfig.Builder<Object> builder, IntervalFunction intervalFunction) {
+        builder.intervalBiFunction(IntervalBiFunction.ofIntervalFunction(intervalFunction));
     }
 
     /**

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/CommonRetryConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/CommonRetryConfigurationPropertiesTest.java
@@ -1,0 +1,96 @@
+package io.github.resilience4j.common.retry.configuration;
+
+import io.github.resilience4j.common.CompositeCustomizer;
+import io.github.resilience4j.retry.RetryConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class CommonRetryConfigurationPropertiesTest {
+
+    private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> WITH_WAIT_DURATION = instanceProperties -> instanceProperties.setWaitDuration(Duration.ofSeconds(1));
+    private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> ENABLE_EXPONENTIAL_BACKOFF = instanceProperties -> instanceProperties.setEnableExponentialBackoff(true);
+    private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> WITH_BACKOFF_MULTIPLIER = instanceProperties -> instanceProperties.setExponentialBackoffMultiplier(2.0);
+    private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> WITH_EXPONENTIAL_MAX_WAIT_DURATION = instanceProperties -> instanceProperties.setExponentialMaxWaitDuration(Duration.ofSeconds(5));
+    private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> ENABLE_RANDOMIZED_WAIT = instanceProperties -> instanceProperties.setEnableRandomizedWait(true);
+    private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> WITH_RANDOMIZED_FACTOR = instanceProperties -> instanceProperties.setRandomizedWaitFactor(0.5);
+
+    @Test
+    public void createRetryConfig_withDefault() {
+        testCreateRetryConfig();
+    }
+
+    @Test
+    public void createRetryConfig_withWaitDuration() {
+        testCreateRetryConfig(WITH_WAIT_DURATION);
+    }
+
+    @Test
+    public void createRetryConfig_withExponentialBackoff() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_EXPONENTIAL_BACKOFF);
+    }
+
+    @Test
+    public void createRetryConfig_withBackoffMultiplier() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER);
+    }
+
+    @Test
+    public void createRetryConfig_withExponentialMaxWaitDuration() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER, WITH_EXPONENTIAL_MAX_WAIT_DURATION);
+    }
+
+    @Test
+    public void createRetryConfig_withRandomizedWait() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT);
+    }
+
+    @Test
+    public void createRetryConfig_withRandomizedFactor() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, WITH_RANDOMIZED_FACTOR);
+    }
+
+    @Test
+    public void createRetryConfig_withRandomizedExponentialBackoff() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, ENABLE_EXPONENTIAL_BACKOFF);
+    }
+
+    @Test
+    public void createRetryConfig_withRandomizedExponentialBackoffMultiplier() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER);
+    }
+
+    @Test
+    public void createRetryConfig_withRandomizedFactorExponentialBackoffMultiplier() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, WITH_RANDOMIZED_FACTOR, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER);
+    }
+
+    @Test
+    public void createRetryConfig_withRandomizedExponentialMaxWaitDuration() {
+        testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, WITH_RANDOMIZED_FACTOR, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER, WITH_EXPONENTIAL_MAX_WAIT_DURATION);
+    }
+
+    @SafeVarargs
+    private void testCreateRetryConfig(Consumer<CommonRetryConfigurationProperties.InstanceProperties>... customizers) {
+        String defaultConfigurationName = "default";
+        String testConfigurationName = "test";
+
+        CommonRetryConfigurationProperties properties = new CommonRetryConfigurationProperties();
+        properties.getConfigs().put(defaultConfigurationName, new CommonRetryConfigurationProperties.InstanceProperties().setWaitDuration(Duration.ofSeconds(1)));
+
+        CommonRetryConfigurationProperties.InstanceProperties instanceProperties = new CommonRetryConfigurationProperties.InstanceProperties().setBaseConfig(defaultConfigurationName);
+        Arrays.stream(customizers).forEachOrdered(customizer -> customizer.accept(instanceProperties));
+        properties.getInstances().put(testConfigurationName, instanceProperties);
+
+        RetryConfig retryConfig = properties.createRetryConfig(testConfigurationName, new CompositeCustomizer<>(List.of()));
+
+        Assertions.assertThat(retryConfig).isNotNull(); // assert that retryConfig does not throw an exception
+        Assertions.assertThat(retryConfig.getIntervalFunction()).isNull();
+        Assertions.assertThat(retryConfig.getIntervalBiFunction()).isNotNull();
+    }
+
+}

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
@@ -82,8 +82,8 @@ public class RetryConfigurationPropertiesTest {
         assertThat(retry1.getConsumeResultBeforeRetryAttempt().getClass()).isEqualTo(ConsumeResultBeforeRetryAttempt.class);
         assertThat(retry2).isNotNull();
         assertThat(retry2.getMaxAttempts()).isEqualTo(2);
-        assertThat(retry2.getIntervalFunction().apply(1)).isEqualTo(99L);
-        assertThat(retry2.getIntervalFunction().apply(2)).isEqualTo(99L);
+        assertThat(retry2.getIntervalBiFunction().apply(1,null)).isEqualTo(99L);
+        assertThat(retry2.getIntervalBiFunction().apply(2,null)).isEqualTo(99L);
         assertThat(retry2.isFailAfterMaxAttempts()).isFalse();
         assertThat(retry2.getConsumeResultBeforeRetryAttempt()).isNull();
     }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationRxJavaTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationRxJavaTest.java
@@ -17,6 +17,7 @@ package io.github.resilience4j.retry;
 
 import io.github.resilience4j.circuitbreaker.IgnoredException;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse;
+import io.github.resilience4j.core.IntervalBiFunction;
 import io.github.resilience4j.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.retry.configure.RetryAspect;
 import io.github.resilience4j.service.test.TestApplication;
@@ -98,10 +99,10 @@ public class RetryAutoConfigurationRxJavaTest {
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))
             .isFalse();
 
-        Function<Integer, Long> exponentialBackoff = retry.getRetryConfig().getIntervalFunction();
-        assertThat(exponentialBackoff.apply(1)).isEqualTo(100);
-        assertThat(exponentialBackoff.apply(2)).isEqualTo(200);
-        assertThat(exponentialBackoff.apply(3)).isEqualTo(222);
+        IntervalBiFunction<?> exponentialBackoff = retry.getRetryConfig().getIntervalBiFunction();
+        assertThat(exponentialBackoff.apply(1,null)).isEqualTo(100);
+        assertThat(exponentialBackoff.apply(2,null)).isEqualTo(200);
+        assertThat(exponentialBackoff.apply(3,null)).isEqualTo(222);
 
         assertThat(retryAspect.getOrder()).isEqualTo(399);
 

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/RetryAutoConfigurationRxJavaTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/RetryAutoConfigurationRxJavaTest.java
@@ -15,12 +15,13 @@
  */
 package io.github.resilience4j.springboot3.retry;
 
-import io.github.resilience4j.springboot3.circuitbreaker.IgnoredException;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse;
+import io.github.resilience4j.core.IntervalBiFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.springboot3.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.spring6.retry.configure.RetryAspect;
+import io.github.resilience4j.springboot3.circuitbreaker.IgnoredException;
+import io.github.resilience4j.springboot3.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
 import io.github.resilience4j.springboot3.service.test.retry.ReactiveRetryDummyService;
 import org.junit.Test;
@@ -31,7 +32,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -99,10 +99,10 @@ public class RetryAutoConfigurationRxJavaTest {
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))
             .isFalse();
 
-        Function<Integer, Long> exponentialBackoff = retry.getRetryConfig().getIntervalFunction();
-        assertThat(exponentialBackoff.apply(1)).isEqualTo(100);
-        assertThat(exponentialBackoff.apply(2)).isEqualTo(200);
-        assertThat(exponentialBackoff.apply(3)).isEqualTo(222);
+        IntervalBiFunction<?> exponentialBackoff = retry.getRetryConfig().getIntervalBiFunction();
+        assertThat(exponentialBackoff.apply(1, null)).isEqualTo(100);
+        assertThat(exponentialBackoff.apply(2, null)).isEqualTo(200);
+        assertThat(exponentialBackoff.apply(3, null)).isEqualTo(222);
 
         assertThat(retryAspect.getOrder()).isEqualTo(399);
 


### PR DESCRIPTION
…re waitDuration

https://github.com/resilience4j/resilience4j/issues/1404

Configure only waitDuration using intervalBiFunction, but configuring the exponential backoff or randomized used intervalFunction. We end up with both configured, which produces an error.

Modify CommonRetryConfigurationProperties to use intervalBiFunction instead of intervalFunction.